### PR TITLE
Use jpeg preview if original image format is not supported (#2)

### DIFF
--- a/image_processing.py
+++ b/image_processing.py
@@ -13,6 +13,14 @@ import logging
 from typing import Tuple
 from immich_api import get_assets_with_person, download_asset
 
+SUPPORTED_IMAGE_MIME_TYPES = {
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+}
+
 class TqdmLoggingHandler(logging.Handler):
     def __init__(self, level=logging.NOTSET):
         super().__init__(level)
@@ -417,7 +425,8 @@ def process_asset_worker(asset, config: AppConfig):
     """
     try:
         asset_id = asset['id']
-        image_bytes = download_asset(config.api_key, config.base_url, asset_id)
+        use_original = asset['originalMimeType'] in SUPPORTED_IMAGE_MIME_TYPES
+        image_bytes = download_asset(config.api_key, config.base_url, asset_id, use_original)
         image = Image.open(io.BytesIO(image_bytes))
         image = ImageOps.exif_transpose(image)
         image = image.convert("RGB")

--- a/immich_api.py
+++ b/immich_api.py
@@ -94,7 +94,7 @@ def get_assets_with_person(api_key, base_url, person_id, date_from=None, date_to
     return all_assets
 
 
-def download_asset(api_key, base_url, asset_id):
+def download_asset(api_key, base_url, asset_id, use_original=True):
     """
     Downloads the original image asset from the API.
 
@@ -102,11 +102,13 @@ def download_asset(api_key, base_url, asset_id):
         api_key (str): API key for authentication.
         base_url (str): Base URL of the API.
         asset_id (str): The asset's ID.
+        use_original (bool): If True, download the original image; otherwise, download the JPEG preview thumbnail.
 
     Returns:
         bytes: The content of the downloaded image.
     """
     headers = {'x-api-key': api_key}
-    response = requests.get(f'{base_url}/assets/{asset_id}/original', headers=headers)
+    url = f'{base_url}/assets/{asset_id}/original' if use_original else f'{base_url}/assets/{asset_id}/thumbnail?size=preview'
+    response = requests.get(url, headers=headers)
     response.raise_for_status()
     return response.content


### PR DESCRIPTION
This pull request introduces the ability to download either the original image or a JPEG preview thumbnail based on the image's MIME type. This addresses issue #2