### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ This project is open source and available under the [MIT License](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ArnaudCrl/immich-automated-selfie-timelapse&type=date&legend=top-left)](https://www.star-history.com/#ArnaudCrl/immich-automated-selfie-timelapse&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ArnaudCrl/immich-automated-selfie-timelapse&type=date&legend=top-left)](https://star-history.dera.page/#ArnaudCrl/immich-automated-selfie-timelapse&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken because of GitHub stargazer API restrictions. This PR swaps it to a working alternative so the chart renders correctly again.